### PR TITLE
Prevented saving coordinates when window is minimized

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -586,9 +586,12 @@ namespace ArenaHelper
 
         public void OnWindowLocation()
         {
-            // Set window location
-            configdata.windowx = (int)arenawindow.Left;
-            configdata.windowy = (int)arenawindow.Top;
+            // Set window location if not minimized
+            if (arenawindow.Left > -32000 && arenawindow.Top > -32000)
+            {
+                configdata.windowx = (int)arenawindow.Left;
+                configdata.windowy = (int)arenawindow.Top;
+            }
 
             // Don't save yet
             //SaveConfig();


### PR DESCRIPTION
When a window is minimized, its coordinates are set to -32000. If the
user closes the window when it is minimized, they can no longer see it
on subsequent launches. Fixes #16.