### PR TITLE
Added support for asynchronous plugins

### DIFF
--- a/Plugins.cs
+++ b/Plugins.cs
@@ -16,6 +16,7 @@ namespace AHPlugins
         public abstract string Name { get; }
         public abstract string Author { get; }
         public abstract Version Version { get; }
+        public abstract bool IsAsync { get; }
 
         // All virtual functions are optional
 
@@ -25,10 +26,12 @@ namespace AHPlugins
         // defaultvalues: List of 3 tier values for the detected cards
         // Return a list of 3 card values and an optional 4th advice value
         public virtual List<string> GetCardValues(ArenaHelper.Plugin.ArenaData arenadata, List<Card> newcards, List<string> defaultvalues) { return null; }
+        public virtual Task<List<string>> GetCardValuesAsync(ArenaHelper.Plugin.ArenaData arenadata, List<Card> newcards, List<string> defaultvalues) { return Task.FromResult<List<string>>(null); }
 
         // Called when a new arena is started
         // arendata: As before
         public virtual void NewArena(ArenaHelper.Plugin.ArenaData arenadata) { }
+        public virtual Task NewArenaAsync(ArenaHelper.Plugin.ArenaData arenadata) { return Task.FromResult(true); }
 
         // Called when the heroes are detected
         // arendata: As before
@@ -36,11 +39,13 @@ namespace AHPlugins
         // heroname1: name of hero 1
         // heroname2: name of hero 2
         public virtual void HeroesDetected(ArenaHelper.Plugin.ArenaData arenadata, string heroname0, string heroname1, string heroname2) { }
+        public virtual Task HeroesDetectedAsync(ArenaHelper.Plugin.ArenaData arenadata, string heroname0, string heroname1, string heroname2) { return Task.FromResult(true); }
 
         // Called when a hero is picked
         // arendata: As before
         // heroname: name of the hero
         public virtual void HeroPicked(ArenaHelper.Plugin.ArenaData arenadata, string heroname) { }
+        public virtual Task HeroPickedAsync(ArenaHelper.Plugin.ArenaData arenadata, string heroname) { return Task.FromResult(true); }
 
         // Called when the cards are detected
         // arendata: As before
@@ -48,26 +53,31 @@ namespace AHPlugins
         // card1: card 1
         // card2: card 2
         public virtual void CardsDetected(ArenaHelper.Plugin.ArenaData arenadata, Card card0, Card card1, Card card2) { }
+        public virtual Task CardsDetectedAsync(ArenaHelper.Plugin.ArenaData arenadata, Card card0, Card card1, Card card2) { return Task.FromResult(true); }
 
         // Called when a card is picked
         // arendata: As before
         // pickindex: index of the picked card in the range -1 to 2, if -1, no valid pick was detected
         // card: card information, null if invalid card
         public virtual void CardPicked(ArenaHelper.Plugin.ArenaData arenadata, int pickindex, Card card) { }
+        public virtual Task CardPickedAsync(ArenaHelper.Plugin.ArenaData arenadata, int pickindex, Card card) { return Task.FromResult(true); }
 
         // Called when all cards are picked
         // arendata: As before
         public virtual void Done(ArenaHelper.Plugin.ArenaData arenadata) { }
+        public virtual Task DoneAsync(ArenaHelper.Plugin.ArenaData arenadata) { return Task.FromResult(true); }
 
         // Called when Arena Helper window is opened
         // arendata: As before
         // state: the current state of Arena Helper
-        public virtual void ResumeArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state) {}
+        public virtual void ResumeArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state) { }
+        public virtual Task ResumeArenaAsync(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state) { return Task.FromResult(true); }
 
         // Called when Arena Helper window is closed
         // arendata: As before
         // state: the current state of Arena Helper
         public virtual void CloseArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state) { }
+        public virtual Task CloseArenaAsync(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state) { return Task.FromResult(true); }
     }
 }
 
@@ -92,7 +102,7 @@ namespace ArenaHelper
             string[] dllFileNames = null;
             if (Directory.Exists(pluginpath))
             {
-                dllFileNames = Directory.GetFiles(pluginpath, "*.dll");
+                dllFileNames = Directory.GetFiles(pluginpath, "*.dll", SearchOption.AllDirectories);
             }
             else
             {
@@ -148,82 +158,126 @@ namespace ArenaHelper
             }
         }
 
-        public List<string> GetCardValues(ArenaHelper.Plugin.ArenaData arenadata, List<Card> newcards, List<string> defaultvalues)
+        public async Task<List<string>> GetCardValues(ArenaHelper.Plugin.ArenaData arenadata, List<Card> newcards, List<string> defaultvalues)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    return await plugin.GetCardValuesAsync(arenadata, newcards, defaultvalues);
+                }
                 return plugin.GetCardValues(arenadata, newcards, defaultvalues);
             }
             return null;
         }
 
-        public void NewArena(ArenaHelper.Plugin.ArenaData arenadata)
+        public async Task NewArena(ArenaHelper.Plugin.ArenaData arenadata)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.NewArenaAsync(arenadata);
+                    return;
+                }
                 plugin.NewArena(arenadata);
                 return;
             }
         }
 
-        public void HeroesDetected(ArenaHelper.Plugin.ArenaData arenadata, string heroname0, string heroname1, string heroname2)
+        public async Task HeroesDetected(ArenaHelper.Plugin.ArenaData arenadata, string heroname0, string heroname1, string heroname2)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.HeroesDetectedAsync(arenadata, heroname0, heroname1, heroname2);
+                    return;
+                }
                 plugin.HeroesDetected(arenadata, heroname0, heroname1, heroname2);
                 return;
             }
         }
 
-        public void HeroPicked(ArenaHelper.Plugin.ArenaData arenadata, string heroname)
+        public async Task HeroPicked(ArenaHelper.Plugin.ArenaData arenadata, string heroname)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.HeroPickedAsync(arenadata, heroname);
+                    return;
+                }
                 plugin.HeroPicked(arenadata, heroname);
                 return;
             }
         }
 
-        public void CardsDetected(ArenaHelper.Plugin.ArenaData arenadata, Card card0, Card card1, Card card2)
+        public async Task CardsDetected(ArenaHelper.Plugin.ArenaData arenadata, Card card0, Card card1, Card card2)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.CardsDetectedAsync(arenadata, card0, card1, card2);
+                    return;
+                }
                 plugin.CardsDetected(arenadata, card0, card1, card2);
                 return;
             }
         }
 
-        public void CardPicked(ArenaHelper.Plugin.ArenaData arenadata, int pickindex, Card card)
+        public async Task CardPicked(ArenaHelper.Plugin.ArenaData arenadata, int pickindex, Card card)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.CardPickedAsync(arenadata, pickindex, card);
+                    return;
+                }
                 plugin.CardPicked(arenadata, pickindex, card);
                 return;
             }
         }
 
-        public void Done(ArenaHelper.Plugin.ArenaData arenadata)
+        public async Task Done(ArenaHelper.Plugin.ArenaData arenadata)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.DoneAsync(arenadata);
+                    return;
+                }
                 plugin.Done(arenadata);
                 return;
             }
         }
 
-        public void ResumeArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state)
+        public async Task ResumeArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.ResumeArenaAsync(arenadata, state);
+                    return;
+                }
                 plugin.ResumeArena(arenadata, state);
                 return;
             }
         }
 
-        public void CloseArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state)
+        public async Task CloseArena(ArenaHelper.Plugin.ArenaData arenadata, ArenaHelper.Plugin.PluginState state)
         {
             foreach (var plugin in plugins)
             {
+                if (plugin.IsAsync)
+                {
+                    await plugin.CloseArenaAsync(arenadata, state);
+                    return;
+                }
                 plugin.CloseArena(arenadata, state);
                 return;
             }

--- a/TestPlugin/TestPlugin.cs
+++ b/TestPlugin/TestPlugin.cs
@@ -27,6 +27,11 @@ namespace TestPlugin
             get { return new Version("0.0.4"); }
         }
 
+        public override bool IsAsync
+        {
+            get { return false; }
+        }
+
         public TestPlugin()
         {
             // Plugin constructor


### PR DESCRIPTION
I am currently developing a plugin for Arena Helper and found myself needing some asynchronous methods. Most plugins for Arena Helper would do asynchronous operations (mainly API calls) and thus would need Arena Helper to be able to await their results and handlers.

This has been tested and works quite well with my asynchronous plugin and the synchronous test plugin.

For a diff without whitespace: https://github.com/rembound/Arena-Helper/compare/master...SuperGouge:add-asynchronous-plugin-methods?w=0