### PR TITLE
Fix localized card names font

### DIFF
--- a/Controls/Card.xaml
+++ b/Controls/Card.xaml
@@ -17,7 +17,7 @@
                                  FontFamily="/HearthstoneDeckTracker;component/Resources/#Belwe Bd BT"
                                  TextAlignment="Center" FontSize="20" Grid.Column="0" />
         <local:OutlinedTextBlock Height="16" VerticalAlignment="Center" Text="{Binding LocalizedName}"
-                                 FontFamily="/HearthstoneDeckTracker;component/Resources/#Belwe Bd BT"
+                                 FontFamily="{Binding Font}"
                                  TextAlignment="Left" FontSize="13" Grid.Column="1" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
For languages different from English letters which doesn't belong to default font doesn't displays correctly. 
This issue was recently fixed in HDT and I ported solution to Arena-Helper.