### PR TITLE
Update for HDT API changes

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -719,7 +719,7 @@ namespace ArenaHelper
             if (!autosave)
             {
                 // Set the new deck
-                Hearthstone_Deck_Tracker.API.Core.MainWindow.SetNewDeck(deck);
+                Hearthstone_Deck_Tracker.API.Core.MainWindow.ShowDeckEditorFlyout(deck, false);
 
                 // Activate the window
                 Hearthstone_Deck_Tracker.API.Core.MainWindow.ActivateWindow();
@@ -727,10 +727,10 @@ namespace ArenaHelper
             else
             {
                 // Set the new deck in editing mode
-                Hearthstone_Deck_Tracker.API.Core.MainWindow.SetNewDeck(deck, true);
+                Hearthstone_Deck_Tracker.API.Core.MainWindow.ShowDeckEditorFlyout(deck, true);
 
                 // Save the deck
-                Hearthstone_Deck_Tracker.API.Core.MainWindow.SaveDeck(true, SerializableVersion.Default, true);
+                Hearthstone_Deck_Tracker.DeckManager.SaveDeck(deck, true);
 
                 // Select the deck and make it active
                 Hearthstone_Deck_Tracker.API.Core.MainWindow.SelectDeck(deck, true);


### PR DESCRIPTION
HearthstoneDeckTracker updated the API, causing errors when trying to compile Arena Helper with recent HDT binaries. This commit revises the plugin to use the new API.