### PR TITLE
Add support to show hero win rate while selecting (Win rates is requesting from HSReplay)

### DIFF
--- a/ArenaHelper.csproj
+++ b/ArenaHelper.csproj
@@ -81,6 +81,7 @@
       <DependentUpon>ValueOverlay.xaml</DependentUpon>
     </Compile>
     <Compile Include="Detection.cs" />
+    <Compile Include="HeroWinRate.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Plugins.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/HeroWinRate.cs
+++ b/HeroWinRate.cs
@@ -1,0 +1,62 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Linq;
+
+namespace ArenaHelper
+{
+    /// <summary>
+    /// Provides hero win rate information in arena mode. Information is requesting from HSReplay
+    /// </summary>
+    public class HeroWinRate
+    {
+        private const string HSReplyPerformanceSummaryUrl = "https://hsreplay.net/api/v1/analytics/query/player_class_performance_summary";
+        private const int ArenaGameType = 3;
+
+        private Dictionary<string, double> heroWinRateDictionary;
+
+        /// <summary>
+        /// Search for win rate by hero class
+        /// </summary>
+        /// <param name="heroClass">Hero class</param>
+        /// <returns>Win rate of specified hero</returns>
+        public string GetWinRateAsString(string heroClass)
+        {
+            if (heroWinRateDictionary == null)
+            {
+                FillWinRateDictionary();
+            }
+
+            return string.Format("{0:0.0}%", heroWinRateDictionary[heroClass.ToLower()]);
+        }
+
+        private void FillWinRateDictionary()
+        {
+            WebRequest request = WebRequest.Create(HSReplyPerformanceSummaryUrl);
+
+            using (WebResponse response = request.GetResponse())
+            {
+                if ((response as HttpWebResponse).StatusCode != HttpStatusCode.OK)
+                {
+                    throw new System.Exception("Can't get information about hero win rate");
+                }
+
+                using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+                {
+                    string responseBody = reader.ReadToEnd();
+                    dynamic responseObject = JObject.Parse(responseBody);
+
+                    heroWinRateDictionary = new Dictionary<string, double>();
+                    foreach (var heroWinRateDataPair in responseObject.series.data)
+                    {
+                        JArray winRateData = heroWinRateDataPair.Value;
+                        dynamic arenaWinRateData = winRateData.First(data => (data as dynamic).game_type == ArenaGameType);
+                        JValue winRate = arenaWinRateData.win_rate;
+                        heroWinRateDictionary[heroWinRateDataPair.Name.ToLower()] = (double)winRate.Value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -2,7 +2,6 @@
 using System.Drawing;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.IO;
@@ -14,11 +13,8 @@ using Hearthstone_Deck_Tracker.Hearthstone;
 using System.Diagnostics;
 using System.Threading;
 using Newtonsoft.Json;
-using System.Runtime.InteropServices;
-using MahApps.Metro.Controls.Dialogs;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Converters;
-using Hearthstone_Deck_Tracker.Utility;
 using Hearthstone_Deck_Tracker.Utility.Logging;
 using HearthMirror;
 
@@ -1148,7 +1144,7 @@ namespace ArenaHelper
             }
             else if (newstate == PluginState.SearchBigHero)
             {
-                ShowOverlay(false);
+                ShowOverlay(true);
                 arenawindow.DetectedHeroesWarning.Text = "";
                 arenawindow.DetectingPanel.Visibility = System.Windows.Visibility.Hidden;
                 arenawindow.ConfigureHeroPanel.Visibility = System.Windows.Visibility.Hidden;
@@ -1916,9 +1912,13 @@ namespace ArenaHelper
                 return;
 
             // All heroes detected, show them
+            var heroWinRate = new HeroWinRate();
             SetHeroControl(arenawindow.Hero0, arenadata.detectedheroes[0]);
+            SetValueText(0, heroWinRate.GetWinRateAsString(arenadata.detectedheroes[0]));
             SetHeroControl(arenawindow.Hero1, arenadata.detectedheroes[1]);
+            SetValueText(1, heroWinRate.GetWinRateAsString(arenadata.detectedheroes[1]));
             SetHeroControl(arenawindow.Hero2, arenadata.detectedheroes[2]);
+            SetValueText(2, heroWinRate.GetWinRateAsString(arenadata.detectedheroes[2]));
 
             // Update window
             arenawindow.Update();


### PR DESCRIPTION
I missed this feature as it helps to choose most powerfull class for run. Arena Tracker (https://github.com/supertriodo/Arena-Tracker) already have this feature. I will glad to see it in main repo. 

![ArenaHelperHeroWinRate](https://user-images.githubusercontent.com/16517593/55179805-52a67e80-5199-11e9-9b59-72f61b08fdff.png)
